### PR TITLE
Fix __contains lookup with JSONField

### DIFF
--- a/django/contrib/messages/storage/base.py
+++ b/django/contrib/messages/storage/base.py
@@ -25,8 +25,9 @@ class Message:
         self.extra_tags = str(self.extra_tags) if self.extra_tags is not None else None
 
     def __eq__(self, other):
-        return isinstance(other, Message) and self.level == other.level and \
-            self.message == other.message
+        if not isinstance(other, Message):
+            return NotImplemented
+        return self.level == other.level and self.message == other.message
 
     def __str__(self):
         return str(self.message)

--- a/django/contrib/postgres/constraints.py
+++ b/django/contrib/postgres/constraints.py
@@ -89,13 +89,14 @@ class ExclusionConstraint(BaseConstraint):
         return path, args, kwargs
 
     def __eq__(self, other):
-        return (
-            isinstance(other, self.__class__) and
-            self.name == other.name and
-            self.index_type == other.index_type and
-            self.expressions == other.expressions and
-            self.condition == other.condition
-        )
+        if isinstance(other, self.__class__):
+            return (
+                self.name == other.name and
+                self.index_type == other.index_type and
+                self.expressions == other.expressions and
+                self.condition == other.condition
+            )
+        return super().__eq__(other)
 
     def __repr__(self):
         return '<%s: index_type=%s, expressions=%s%s>' % (

--- a/django/contrib/postgres/lookups.py
+++ b/django/contrib/postgres/lookups.py
@@ -8,7 +8,7 @@ class PostgresSimpleLookup(FieldGetDbPrepValueMixin, Lookup):
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
+        params = tuple(lhs_params) + tuple(rhs_params)
         return '%s %s %s' % (lhs, self.operator, rhs), params
 
 

--- a/django/contrib/staticfiles/storage.py
+++ b/django/contrib/staticfiles/storage.py
@@ -398,7 +398,8 @@ class ManifestFilesMixin(HashedFilesMixin):
     def post_process(self, *args, **kwargs):
         self.hashed_files = {}
         yield from super().post_process(*args, **kwargs)
-        self.save_manifest()
+        if not kwargs.get('dry_run'):
+            self.save_manifest()
 
     def save_manifest(self):
         payload = {'paths': self.hashed_files, 'version': self.manifest_version}

--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -324,8 +324,9 @@ class BaseValidator:
             raise ValidationError(self.message, code=self.code, params=params)
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return (
-            isinstance(other, self.__class__) and
             self.limit_value == other.limit_value and
             self.message == other.message and
             self.code == other.code

--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -54,7 +54,7 @@ class Oracle_datetime(datetime.datetime):
 
 class BulkInsertMapper:
     BLOB = 'TO_BLOB(%s)'
-    CBLOB = 'TO_CLOB(%s)'
+    CLOB = 'TO_CLOB(%s)'
     DATE = 'TO_DATE(%s)'
     INTERVAL = 'CAST(%s as INTERVAL DAY(9) TO SECOND(6))'
     NUMBER = 'TO_NUMBER(%s)'
@@ -74,6 +74,6 @@ class BulkInsertMapper:
         'PositiveIntegerField': NUMBER,
         'PositiveSmallIntegerField': NUMBER,
         'SmallIntegerField': NUMBER,
-        'TextField': CBLOB,
+        'TextField': CLOB,
         'TimeField': TIMESTAMP,
     }

--- a/django/db/backends/oracle/utils.py
+++ b/django/db/backends/oracle/utils.py
@@ -54,6 +54,7 @@ class Oracle_datetime(datetime.datetime):
 
 class BulkInsertMapper:
     BLOB = 'TO_BLOB(%s)'
+    CBLOB = 'TO_CLOB(%s)'
     DATE = 'TO_DATE(%s)'
     INTERVAL = 'CAST(%s as INTERVAL DAY(9) TO SECOND(6))'
     NUMBER = 'TO_NUMBER(%s)'
@@ -73,5 +74,6 @@ class BulkInsertMapper:
         'PositiveIntegerField': NUMBER,
         'PositiveSmallIntegerField': NUMBER,
         'SmallIntegerField': NUMBER,
+        'TextField': CBLOB,
         'TimeField': TIMESTAMP,
     }

--- a/django/db/migrations/serializer.py
+++ b/django/db/migrations/serializer.py
@@ -120,9 +120,10 @@ class EnumSerializer(BaseSerializer):
     def serialize(self):
         enum_class = self.value.__class__
         module = enum_class.__module__
-        v_string, v_imports = serializer_factory(self.value.value).serialize()
-        imports = {'import %s' % module, *v_imports}
-        return "%s.%s(%s)" % (module, enum_class.__name__, v_string), imports
+        return (
+            '%s.%s[%r]' % (module, enum_class.__name__, self.value.name),
+            {'import %s' % module},
+        )
 
 
 class FloatSerializer(BaseSimpleSerializer):

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1711,6 +1711,8 @@ class Model(metaclass=ModelBase):
                     fld = _cls._meta.get_field(part)
                     if fld.is_relation:
                         _cls = fld.get_path_info()[-1].to_opts.model
+                    else:
+                        _cls = None
                 except (FieldDoesNotExist, AttributeError):
                     if fld is None or fld.get_transform(part) is None:
                         errors.append(

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -522,7 +522,7 @@ class Model(metaclass=ModelBase):
 
     def __eq__(self, other):
         if not isinstance(other, Model):
-            return False
+            return NotImplemented
         if self._meta.concrete_model != other._meta.concrete_model:
             return False
         my_pk = self.pk

--- a/django/db/models/base.py
+++ b/django/db/models/base.py
@@ -1708,7 +1708,11 @@ class Model(metaclass=ModelBase):
             fld = None
             for part in field.split(LOOKUP_SEP):
                 try:
-                    fld = _cls._meta.get_field(part)
+                    # pk is an alias that won't be found by opts.get_field.
+                    if part == 'pk':
+                        fld = _cls._meta.pk
+                    else:
+                        fld = _cls._meta.get_field(part)
                     if fld.is_relation:
                         _cls = fld.get_path_info()[-1].to_opts.model
                     else:

--- a/django/db/models/constraints.py
+++ b/django/db/models/constraints.py
@@ -54,11 +54,9 @@ class CheckConstraint(BaseConstraint):
         return "<%s: check='%s' name=%r>" % (self.__class__.__name__, self.check, self.name)
 
     def __eq__(self, other):
-        return (
-            isinstance(other, CheckConstraint) and
-            self.name == other.name and
-            self.check == other.check
-        )
+        if isinstance(other, CheckConstraint):
+            return self.name == other.name and self.check == other.check
+        return super().__eq__(other)
 
     def deconstruct(self):
         path, args, kwargs = super().deconstruct()
@@ -106,12 +104,13 @@ class UniqueConstraint(BaseConstraint):
         )
 
     def __eq__(self, other):
-        return (
-            isinstance(other, UniqueConstraint) and
-            self.name == other.name and
-            self.fields == other.fields and
-            self.condition == other.condition
-        )
+        if isinstance(other, UniqueConstraint):
+            return (
+                self.name == other.name and
+                self.fields == other.fields and
+                self.condition == other.condition
+            )
+        return super().__eq__(other)
 
     def deconstruct(self):
         path, args, kwargs = super().deconstruct()

--- a/django/db/models/expressions.py
+++ b/django/db/models/expressions.py
@@ -401,7 +401,9 @@ class BaseExpression:
         return tuple(identity)
 
     def __eq__(self, other):
-        return isinstance(other, BaseExpression) and other.identity == self.identity
+        if not isinstance(other, BaseExpression):
+            return NotImplemented
+        return other.identity == self.identity
 
     def __hash__(self):
         return hash(self.identity)

--- a/django/db/models/indexes.py
+++ b/django/db/models/indexes.py
@@ -112,4 +112,6 @@ class Index:
         )
 
     def __eq__(self, other):
-        return (self.__class__ == other.__class__) and (self.deconstruct() == other.deconstruct())
+        if self.__class__ == other.__class__:
+            return self.deconstruct() == other.deconstruct()
+        return NotImplemented

--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1543,7 +1543,9 @@ class Prefetch:
         return None
 
     def __eq__(self, other):
-        return isinstance(other, Prefetch) and self.prefetch_to == other.prefetch_to
+        if not isinstance(other, Prefetch):
+            return NotImplemented
+        return self.prefetch_to == other.prefetch_to
 
     def __hash__(self):
         return hash((self.__class__, self.prefetch_to))

--- a/django/db/models/query_utils.py
+++ b/django/db/models/query_utils.py
@@ -309,8 +309,9 @@ class FilteredRelation:
         self.path = []
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return (
-            isinstance(other, self.__class__) and
             self.relation_name == other.relation_name and
             self.alias == other.alias and
             self.condition == other.condition

--- a/django/template/context.py
+++ b/django/template/context.py
@@ -124,12 +124,10 @@ class BaseContext:
         """
         Compare two contexts by comparing theirs 'dicts' attributes.
         """
-        return (
-            isinstance(other, BaseContext) and
-            # because dictionaries can be put in different order
-            # we have to flatten them like in templates
-            self.flatten() == other.flatten()
-        )
+        if not isinstance(other, BaseContext):
+            return NotImplemented
+        # flatten dictionaries because they can be put in a different order.
+        return self.flatten() == other.flatten()
 
 
 class Context(BaseContext):

--- a/django/utils/http.py
+++ b/django/utils/http.py
@@ -176,10 +176,14 @@ def parse_http_date(date):
     try:
         year = int(m.group('year'))
         if year < 100:
-            if year < 70:
-                year += 2000
+            current_year = datetime.datetime.utcnow().year
+            current_century = current_year - (current_year % 100)
+            if year - (current_year % 100) > 50:
+                # year that appears to be more than 50 years in the future are
+                # interpreted as representing the past.
+                year += current_century - 100
             else:
-                year += 1900
+                year += current_century
         month = MONTHS.index(m.group('mon').lower()) + 1
         day = int(m.group('day'))
         hour = int(m.group('hour'))

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -802,8 +802,10 @@ The behavior of this command changes depending on the arguments provided:
 * ``<app_label> <migrationname>``: Brings the database schema to a state where
   the named migration is applied, but no later migrations in the same app are
   applied. This may involve unapplying migrations if you have previously
-  migrated past the named migration. Use the name ``zero`` to migrate all the
-  way back i.e. to revert all applied migrations for an app.
+  migrated past the named migration. You can use a prefix of the migration
+  name, e.g. ``0001``, as long as it's unique for the given app name. Use the
+  name ``zero`` to migrate all the way back i.e. to revert all applied
+  migrations for an app.
 
 .. warning::
 

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -805,6 +805,12 @@ The behavior of this command changes depending on the arguments provided:
   migrated past the named migration. Use the name ``zero`` to unapply all
   migrations for an app.
 
+.. warning::
+
+    When unapplying migrations, all dependent migrations will also be
+    unapplied, regardless of ``<app_label>``. You can use ``--plan`` to check
+    which migrations will be unapplied.
+
 .. django-admin-option:: --database DATABASE
 
 Specifies the database to migrate. Defaults to ``default``.

--- a/docs/ref/django-admin.txt
+++ b/docs/ref/django-admin.txt
@@ -802,8 +802,8 @@ The behavior of this command changes depending on the arguments provided:
 * ``<app_label> <migrationname>``: Brings the database schema to a state where
   the named migration is applied, but no later migrations in the same app are
   applied. This may involve unapplying migrations if you have previously
-  migrated past the named migration. Use the name ``zero`` to unapply all
-  migrations for an app.
+  migrated past the named migration. Use the name ``zero`` to migrate all the
+  way back i.e. to revert all applied migrations for an app.
 
 .. warning::
 

--- a/docs/ref/utils.txt
+++ b/docs/ref/utils.txt
@@ -945,11 +945,14 @@ appropriate entities.
     post-transition respectively.
 
     The ``pytz.NonExistentTimeError`` exception is raised if you try to make
-    ``value`` aware during a DST transition such that the time never occurred
-    (when entering into DST). Setting ``is_dst`` to ``True`` or ``False`` will
-    avoid the exception by moving the hour backwards or forwards by 1
-    respectively. For example, ``is_dst=True`` would change a nonexistent
-    time of 2:30 to 1:30 and ``is_dst=False`` would change the time to 3:30.
+    ``value`` aware during a DST transition such that the time never occurred.
+    For example, if the 2:00 hour is skipped during a DST transition, trying to
+    make 2:30 aware in that time zone will raise an exception. To avoid that
+    you can use ``is_dst`` to specify how ``make_aware()`` should interpret
+    such a nonexistent time. If ``is_dst=True`` then the above time would be
+    interpreted as 2:30 DST time (equivalent to 1:30 local time). Conversely,
+    if ``is_dst=False`` the time would be interpreted as 2:30 standard time
+    (equivalent to 3:30 local time).
 
 .. function:: make_naive(value, timezone=None)
 

--- a/docs/releases/1.11.25.txt
+++ b/docs/releases/1.11.25.txt
@@ -2,7 +2,7 @@
 Django 1.11.25 release notes
 ============================
 
-*Expected October 1, 2019*
+*October 1, 2019*
 
 Django 1.11.25 fixes a regression in 1.11.23.
 

--- a/docs/releases/2.1.13.txt
+++ b/docs/releases/2.1.13.txt
@@ -2,7 +2,7 @@
 Django 2.1.13 release notes
 ===========================
 
-*Expected October 1, 2019*
+*October 1, 2019*
 
 Django 2.1.13 fixes a regression in 2.1.11.
 

--- a/docs/releases/2.2.6.txt
+++ b/docs/releases/2.2.6.txt
@@ -2,7 +2,7 @@
 Django 2.2.6 release notes
 ==========================
 
-*Expected October 1, 2019*
+*October 1, 2019*
 
 Django 2.2.6 fixes several bugs in 2.2.5.
 

--- a/docs/releases/2.2.7.txt
+++ b/docs/releases/2.2.7.txt
@@ -1,0 +1,12 @@
+==========================
+Django 2.2.7 release notes
+==========================
+
+*Expected November 1, 2019*
+
+Django 2.2.7 fixes several bugs in 2.2.6.
+
+Bugfixes
+========
+
+* ...

--- a/docs/releases/index.txt
+++ b/docs/releases/index.txt
@@ -39,6 +39,7 @@ versions of the documentation contain the release notes for any later releases.
 .. toctree::
    :maxdepth: 1
 
+   2.2.7
    2.2.6
    2.2.5
    2.2.4

--- a/docs/topics/migrations.txt
+++ b/docs/topics/migrations.txt
@@ -347,6 +347,30 @@ Note that this only works given two things:
   that your database doesn't match your models, you'll just get errors when
   migrations try to modify those tables.
 
+Reverting migrations
+====================
+
+Any migration can be reverted with :djadmin:`migrate` by using the number of
+previous migrations::
+
+    $ python manage.py migrate books 0002
+    Operations to perform:
+      Target specific migration: 0002_auto, from books
+    Running migrations:
+      Rendering model states... DONE
+      Unapplying books.0003_auto... OK
+
+If you want to revert all migrations applied for an app, use the name
+``zero``::
+
+    $ python manage.py migrate books zero
+    Operations to perform:
+      Unapply all migrations: books
+    Running migrations:
+      Rendering model states... DONE
+      Unapplying books.0002_auto... OK
+      Unapplying books.0001_initial... OK
+
 .. _historical-models:
 
 Historical models

--- a/tests/basic/tests.py
+++ b/tests/basic/tests.py
@@ -1,5 +1,6 @@
 import threading
 from datetime import datetime, timedelta
+from unittest import mock
 
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import DEFAULT_DB_ALIAS, DatabaseError, connections, models
@@ -354,6 +355,7 @@ class ModelTest(TestCase):
         self.assertNotEqual(object(), Article(id=1))
         a = Article()
         self.assertEqual(a, a)
+        self.assertEqual(a, mock.ANY)
         self.assertNotEqual(Article(), a)
 
     def test_hash(self):

--- a/tests/bulk_create/tests.py
+++ b/tests/bulk_create/tests.py
@@ -49,6 +49,16 @@ class BulkCreateTests(TestCase):
         Country.objects.bulk_create([Country(description='Ж' * 3000)])
         self.assertEqual(Country.objects.count(), 1)
 
+    @skipUnlessDBFeature('has_bulk_insert')
+    def test_long_and_short_text(self):
+        Country.objects.bulk_create([
+            Country(description='a' * 4001),
+            Country(description='a'),
+            Country(description='Ж' * 2001),
+            Country(description='Ж'),
+        ])
+        self.assertEqual(Country.objects.count(), 4)
+
     def test_multi_table_inheritance_unsupported(self):
         expected_message = "Can't bulk create a multi-table inherited model"
         with self.assertRaisesMessage(ValueError, expected_message):

--- a/tests/constraints/tests.py
+++ b/tests/constraints/tests.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, connection, models
 from django.db.models.constraints import BaseConstraint
@@ -39,6 +41,7 @@ class CheckConstraintTests(TestCase):
             models.CheckConstraint(check=check1, name='price'),
             models.CheckConstraint(check=check1, name='price'),
         )
+        self.assertEqual(models.CheckConstraint(check=check1, name='price'), mock.ANY)
         self.assertNotEqual(
             models.CheckConstraint(check=check1, name='price'),
             models.CheckConstraint(check=check1, name='price2'),
@@ -101,6 +104,10 @@ class UniqueConstraintTests(TestCase):
         self.assertEqual(
             models.UniqueConstraint(fields=['foo', 'bar'], name='unique'),
             models.UniqueConstraint(fields=['foo', 'bar'], name='unique'),
+        )
+        self.assertEqual(
+            models.UniqueConstraint(fields=['foo', 'bar'], name='unique'),
+            mock.ANY,
         )
         self.assertNotEqual(
             models.UniqueConstraint(fields=['foo', 'bar'], name='unique'),

--- a/tests/expressions/tests.py
+++ b/tests/expressions/tests.py
@@ -3,6 +3,7 @@ import pickle
 import unittest
 import uuid
 from copy import deepcopy
+from unittest import mock
 
 from django.core.exceptions import FieldError
 from django.db import DatabaseError, connection, models
@@ -965,6 +966,7 @@ class SimpleExpressionTests(SimpleTestCase):
             Expression(models.IntegerField()),
             Expression(output_field=models.IntegerField())
         )
+        self.assertEqual(Expression(models.IntegerField()), mock.ANY)
         self.assertNotEqual(
             Expression(models.IntegerField()),
             Expression(models.CharField())

--- a/tests/filtered_relation/tests.py
+++ b/tests/filtered_relation/tests.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.db import connection, transaction
 from django.db.models import Case, Count, F, FilteredRelation, Q, When
 from django.test import TestCase
@@ -322,6 +324,9 @@ class FilteredRelationTests(TestCase):
             ).filter(generic_authored_book__isnull=False),
             [self.book1]
         )
+
+    def test_eq(self):
+        self.assertEqual(FilteredRelation('book', condition=Q(book__title='b')), mock.ANY)
 
 
 class FilteredRelationAggregationTests(TestCase):

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -814,6 +814,26 @@ class OtherModelTests(SimpleTestCase):
             )
         ])
 
+    def test_ordering_pointing_multiple_times_to_model_fields(self):
+        class Parent(models.Model):
+            field1 = models.CharField(max_length=100)
+            field2 = models.CharField(max_length=100)
+
+        class Child(models.Model):
+            parent = models.ForeignKey(Parent, models.CASCADE)
+
+            class Meta:
+                ordering = ('parent__field1__field2',)
+
+        self.assertEqual(Child.check(), [
+            Error(
+                "'ordering' refers to the nonexistent field, related field, "
+                "or lookup 'parent__field1__field2'.",
+                obj=Child,
+                id='models.E015',
+            )
+        ])
+
     def test_ordering_allows_registered_lookups(self):
         class Model(models.Model):
             test = models.CharField(max_length=100)

--- a/tests/invalid_models_tests/test_models.py
+++ b/tests/invalid_models_tests/test_models.py
@@ -844,6 +844,18 @@ class OtherModelTests(SimpleTestCase):
         with register_lookup(models.CharField, Lower):
             self.assertEqual(Model.check(), [])
 
+    def test_ordering_pointing_to_related_model_pk(self):
+        class Parent(models.Model):
+            pass
+
+        class Child(models.Model):
+            parent = models.ForeignKey(Parent, models.CASCADE)
+
+            class Meta:
+                ordering = ('parent__pk',)
+
+        self.assertEqual(Child.check(), [])
+
     def test_ordering_pointing_to_foreignkey_field(self):
         class Parent(models.Model):
             pass

--- a/tests/messages_tests/tests.py
+++ b/tests/messages_tests/tests.py
@@ -1,0 +1,14 @@
+from django.contrib.messages import constants
+from django.contrib.messages.storage.base import Message
+from django.test import SimpleTestCase
+
+
+class MessageTests(SimpleTestCase):
+    def test_eq(self):
+        msg_1 = Message(constants.INFO, 'Test message 1')
+        msg_2 = Message(constants.INFO, 'Test message 2')
+        msg_3 = Message(constants.WARNING, 'Test message 1')
+        self.assertEqual(msg_1, msg_1)
+        self.assertNotEqual(msg_1, msg_2)
+        self.assertNotEqual(msg_1, msg_3)
+        self.assertNotEqual(msg_2, msg_3)

--- a/tests/messages_tests/tests.py
+++ b/tests/messages_tests/tests.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.contrib.messages import constants
 from django.contrib.messages.storage.base import Message
 from django.test import SimpleTestCase
@@ -9,6 +11,7 @@ class MessageTests(SimpleTestCase):
         msg_2 = Message(constants.INFO, 'Test message 2')
         msg_3 = Message(constants.WARNING, 'Test message 1')
         self.assertEqual(msg_1, msg_1)
+        self.assertEqual(msg_1, mock.ANY)
         self.assertNotEqual(msg_1, msg_2)
         self.assertNotEqual(msg_1, msg_3)
         self.assertNotEqual(msg_2, msg_3)

--- a/tests/migrations/test_writer.py
+++ b/tests/migrations/test_writer.py
@@ -257,6 +257,10 @@ class WriterTests(SimpleTestCase):
             A = 'a-value'
             B = 'value-b'
 
+        class TextTranslatedEnum(enum.Enum):
+            A = _('a-value')
+            B = _('value-b')
+
         class BinaryEnum(enum.Enum):
             A = b'a-value'
             B = b'value-b'
@@ -267,15 +271,19 @@ class WriterTests(SimpleTestCase):
 
         self.assertSerializedResultEqual(
             TextEnum.A,
-            ("migrations.test_writer.TextEnum('a-value')", {'import migrations.test_writer'})
+            ("migrations.test_writer.TextEnum['A']", {'import migrations.test_writer'})
+        )
+        self.assertSerializedResultEqual(
+            TextTranslatedEnum.A,
+            ("migrations.test_writer.TextTranslatedEnum['A']", {'import migrations.test_writer'})
         )
         self.assertSerializedResultEqual(
             BinaryEnum.A,
-            ("migrations.test_writer.BinaryEnum(b'a-value')", {'import migrations.test_writer'})
+            ("migrations.test_writer.BinaryEnum['A']", {'import migrations.test_writer'})
         )
         self.assertSerializedResultEqual(
             IntEnum.B,
-            ("migrations.test_writer.IntEnum(2)", {'import migrations.test_writer'})
+            ("migrations.test_writer.IntEnum['B']", {'import migrations.test_writer'})
         )
 
         field = models.CharField(default=TextEnum.B, choices=[(m.value, m) for m in TextEnum])
@@ -283,27 +291,39 @@ class WriterTests(SimpleTestCase):
         self.assertEqual(
             string,
             "models.CharField(choices=["
-            "('a-value', migrations.test_writer.TextEnum('a-value')), "
-            "('value-b', migrations.test_writer.TextEnum('value-b'))], "
-            "default=migrations.test_writer.TextEnum('value-b'))"
+            "('a-value', migrations.test_writer.TextEnum['A']), "
+            "('value-b', migrations.test_writer.TextEnum['B'])], "
+            "default=migrations.test_writer.TextEnum['B'])"
+        )
+        field = models.CharField(
+            default=TextTranslatedEnum.A,
+            choices=[(m.value, m) for m in TextTranslatedEnum],
+        )
+        string = MigrationWriter.serialize(field)[0]
+        self.assertEqual(
+            string,
+            "models.CharField(choices=["
+            "('a-value', migrations.test_writer.TextTranslatedEnum['A']), "
+            "('value-b', migrations.test_writer.TextTranslatedEnum['B'])], "
+            "default=migrations.test_writer.TextTranslatedEnum['A'])"
         )
         field = models.CharField(default=BinaryEnum.B, choices=[(m.value, m) for m in BinaryEnum])
         string = MigrationWriter.serialize(field)[0]
         self.assertEqual(
             string,
             "models.CharField(choices=["
-            "(b'a-value', migrations.test_writer.BinaryEnum(b'a-value')), "
-            "(b'value-b', migrations.test_writer.BinaryEnum(b'value-b'))], "
-            "default=migrations.test_writer.BinaryEnum(b'value-b'))"
+            "(b'a-value', migrations.test_writer.BinaryEnum['A']), "
+            "(b'value-b', migrations.test_writer.BinaryEnum['B'])], "
+            "default=migrations.test_writer.BinaryEnum['B'])"
         )
         field = models.IntegerField(default=IntEnum.A, choices=[(m.value, m) for m in IntEnum])
         string = MigrationWriter.serialize(field)[0]
         self.assertEqual(
             string,
             "models.IntegerField(choices=["
-            "(1, migrations.test_writer.IntEnum(1)), "
-            "(2, migrations.test_writer.IntEnum(2))], "
-            "default=migrations.test_writer.IntEnum(1))"
+            "(1, migrations.test_writer.IntEnum['A']), "
+            "(2, migrations.test_writer.IntEnum['B'])], "
+            "default=migrations.test_writer.IntEnum['A'])"
         )
 
     def test_serialize_choices(self):
@@ -454,7 +474,7 @@ class WriterTests(SimpleTestCase):
         # Test a string regex with flag
         validator = RegexValidator(r'^[0-9]+$', flags=re.S)
         string = MigrationWriter.serialize(validator)[0]
-        self.assertEqual(string, "django.core.validators.RegexValidator('^[0-9]+$', flags=re.RegexFlag(16))")
+        self.assertEqual(string, "django.core.validators.RegexValidator('^[0-9]+$', flags=re.RegexFlag['DOTALL'])")
         self.serialize_round_trip(validator)
 
         # Test message and code

--- a/tests/model_indexes/tests.py
+++ b/tests/model_indexes/tests.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.conf import settings
 from django.db import connection, models
 from django.db.models.query_utils import Q
@@ -28,6 +30,7 @@ class SimpleIndexesTests(SimpleTestCase):
         same_index.model = Book
         another_index.model = Book
         self.assertEqual(index, same_index)
+        self.assertEqual(index, mock.ANY)
         self.assertNotEqual(index, another_index)
 
     def test_index_fields_type(self):

--- a/tests/postgres_tests/test_constraints.py
+++ b/tests/postgres_tests/test_constraints.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 
 from django.db import connection, transaction
 from django.db.models import F, Func, Q
@@ -175,6 +176,7 @@ class ExclusionConstraintTests(PostgreSQLTestCase):
             condition=Q(cancelled=False),
         )
         self.assertEqual(constraint_1, constraint_1)
+        self.assertEqual(constraint_1, mock.ANY)
         self.assertNotEqual(constraint_1, constraint_2)
         self.assertNotEqual(constraint_1, constraint_3)
         self.assertNotEqual(constraint_2, constraint_3)

--- a/tests/postgres_tests/test_json.py
+++ b/tests/postgres_tests/test_json.py
@@ -386,6 +386,9 @@ class TestQuerying(PostgreSQLTestCase):
             queries[0]['sql'],
         )
 
+    def test_field_contains(self):
+        self.assertTrue(JSONModel.objects.filter(field__d__contains='e').exists())
+
 
 @isolate_apps('postgres_tests')
 class TestChecks(PostgreSQLSimpleTestCase):

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection
@@ -243,6 +245,7 @@ class PrefetchRelatedTests(TestDataMixin, TestCase):
         prefetch_1 = Prefetch('authors', queryset=Author.objects.all())
         prefetch_2 = Prefetch('books', queryset=Book.objects.all())
         self.assertEqual(prefetch_1, prefetch_1)
+        self.assertEqual(prefetch_1, mock.ANY)
         self.assertNotEqual(prefetch_1, prefetch_2)
 
     def test_forward_m2m_to_attr_conflict(self):

--- a/tests/prefetch_related/tests.py
+++ b/tests/prefetch_related/tests.py
@@ -239,6 +239,12 @@ class PrefetchRelatedTests(TestDataMixin, TestCase):
         self.assertIn('prefetch_related', str(cm.exception))
         self.assertIn("name", str(cm.exception))
 
+    def test_prefetch_eq(self):
+        prefetch_1 = Prefetch('authors', queryset=Author.objects.all())
+        prefetch_2 = Prefetch('books', queryset=Book.objects.all())
+        self.assertEqual(prefetch_1, prefetch_1)
+        self.assertNotEqual(prefetch_1, prefetch_2)
+
     def test_forward_m2m_to_attr_conflict(self):
         msg = 'to_attr=authors conflicts with a field on the Book model.'
         authors = Author.objects.all()

--- a/tests/staticfiles_tests/test_management.py
+++ b/tests/staticfiles_tests/test_management.py
@@ -334,6 +334,11 @@ class TestCollectionDryRun(TestNoFilesCreated, CollectionTestCase):
         super().run_collectstatic(dry_run=True)
 
 
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.ManifestStaticFilesStorage')
+class TestCollectionDryRunManifestStaticFilesStorage(TestCollectionDryRun):
+    pass
+
+
 class TestCollectionFilesOverride(CollectionTestCase):
     """
     Test overriding duplicated files by ``collectstatic`` management command.

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.http import HttpRequest
 from django.template import (
     Context, Engine, RequestContext, Template, Variable, VariableDoesNotExist,
@@ -18,6 +20,7 @@ class ContextTests(SimpleTestCase):
         self.assertEqual(c.pop(), {"a": 2})
         self.assertEqual(c["a"], 1)
         self.assertEqual(c.get("foo", 42), 42)
+        self.assertEqual(c, mock.ANY)
 
     def test_push_context_manager(self):
         c = Context({"a": 1})

--- a/tests/utils_tests/test_autoreload.py
+++ b/tests/utils_tests/test_autoreload.py
@@ -651,7 +651,7 @@ class WatchmanReloaderTests(ReloaderTests, IntegrationTests):
 
     @mock.patch.dict(os.environ, {'DJANGO_WATCHMAN_TIMEOUT': '10'})
     def test_setting_timeout_from_environment_variable(self):
-        self.assertEqual(self.RELOADER_CLS.client_timeout, 10)
+        self.assertEqual(self.RELOADER_CLS().client_timeout, 10)
 
 
 @skipIf(on_macos_with_hfs(), "These tests do not work with HFS+ as a filesystem")

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -317,8 +317,18 @@ class HttpDateProcessingTests(unittest.TestCase):
         self.assertEqual(datetime.utcfromtimestamp(parsed), datetime(1994, 11, 6, 8, 49, 37))
 
     def test_parsing_rfc850(self):
-        parsed = parse_http_date('Sunday, 06-Nov-94 08:49:37 GMT')
-        self.assertEqual(datetime.utcfromtimestamp(parsed), datetime(1994, 11, 6, 8, 49, 37))
+        tests = (
+            ('Tuesday, 31-Dec-69 08:49:37 GMT', datetime(2069, 12, 31, 8, 49, 37)),
+            ('Tuesday, 10-Nov-70 08:49:37 GMT', datetime(1970, 11, 10, 8, 49, 37)),
+            ('Sunday, 06-Nov-94 08:49:37 GMT', datetime(1994, 11, 6, 8, 49, 37)),
+            ('Friday, 31-Dec-71 08:49:37 GMT', datetime(1971, 12, 31, 8, 49, 37)),
+            ('Sunday, 31-Dec-00 08:49:37 GMT', datetime(2000, 12, 31, 8, 49, 37)),
+            ('Friday, 31-Dec-99 08:49:37 GMT', datetime(1999, 12, 31, 8, 49, 37)),
+        )
+        for rfc850str, expected_date in tests:
+            with self.subTest(rfc850str=rfc850str):
+                parsed = parse_http_date(rfc850str)
+                self.assertEqual(datetime.utcfromtimestamp(parsed), expected_date)
 
     def test_parsing_asctime(self):
         parsed = parse_http_date('Sun Nov  6 08:49:37 1994')

--- a/tests/utils_tests/test_http.py
+++ b/tests/utils_tests/test_http.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime
+from unittest import mock
 
 from django.test import SimpleTestCase, ignore_warnings
 from django.utils.datastructures import MultiValueDict
@@ -316,17 +317,25 @@ class HttpDateProcessingTests(unittest.TestCase):
         parsed = parse_http_date('Sun, 06 Nov 1994 08:49:37 GMT')
         self.assertEqual(datetime.utcfromtimestamp(parsed), datetime(1994, 11, 6, 8, 49, 37))
 
-    def test_parsing_rfc850(self):
+    @mock.patch('django.utils.http.datetime.datetime')
+    def test_parsing_rfc850(self, mocked_datetime):
+        mocked_datetime.side_effect = datetime
+        mocked_datetime.utcnow = mock.Mock()
+        utcnow_1 = datetime(2019, 11, 6, 8, 49, 37)
+        utcnow_2 = datetime(2020, 11, 6, 8, 49, 37)
+        utcnow_3 = datetime(2048, 11, 6, 8, 49, 37)
         tests = (
-            ('Tuesday, 31-Dec-69 08:49:37 GMT', datetime(2069, 12, 31, 8, 49, 37)),
-            ('Tuesday, 10-Nov-70 08:49:37 GMT', datetime(1970, 11, 10, 8, 49, 37)),
-            ('Sunday, 06-Nov-94 08:49:37 GMT', datetime(1994, 11, 6, 8, 49, 37)),
-            ('Friday, 31-Dec-71 08:49:37 GMT', datetime(1971, 12, 31, 8, 49, 37)),
-            ('Sunday, 31-Dec-00 08:49:37 GMT', datetime(2000, 12, 31, 8, 49, 37)),
-            ('Friday, 31-Dec-99 08:49:37 GMT', datetime(1999, 12, 31, 8, 49, 37)),
+            (utcnow_1, 'Tuesday, 31-Dec-69 08:49:37 GMT', datetime(2069, 12, 31, 8, 49, 37)),
+            (utcnow_1, 'Tuesday, 10-Nov-70 08:49:37 GMT', datetime(1970, 11, 10, 8, 49, 37)),
+            (utcnow_1, 'Sunday, 06-Nov-94 08:49:37 GMT', datetime(1994, 11, 6, 8, 49, 37)),
+            (utcnow_2, 'Wednesday, 31-Dec-70 08:49:37 GMT', datetime(2070, 12, 31, 8, 49, 37)),
+            (utcnow_2, 'Friday, 31-Dec-71 08:49:37 GMT', datetime(1971, 12, 31, 8, 49, 37)),
+            (utcnow_3, 'Sunday, 31-Dec-00 08:49:37 GMT', datetime(2000, 12, 31, 8, 49, 37)),
+            (utcnow_3, 'Friday, 31-Dec-99 08:49:37 GMT', datetime(1999, 12, 31, 8, 49, 37)),
         )
-        for rfc850str, expected_date in tests:
+        for utcnow, rfc850str, expected_date in tests:
             with self.subTest(rfc850str=rfc850str):
+                mocked_datetime.utcnow.return_value = utcnow
                 parsed = parse_http_date(rfc850str)
                 self.assertEqual(datetime.utcfromtimestamp(parsed), expected_date)
 

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -3,7 +3,7 @@ import re
 import types
 from datetime import datetime, timedelta
 from decimal import Decimal
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
@@ -424,6 +424,7 @@ class TestValidatorEquality(TestCase):
             MaxValueValidator(44),
             MaxValueValidator(44),
         )
+        self.assertEqual(MaxValueValidator(44), mock.ANY)
         self.assertNotEqual(
             MaxValueValidator(44),
             MinValueValidator(44),


### PR DESCRIPTION
When doing `as_sql` the `compiler.compile` executes this to get the sql and params.
https://github.com/django/django/blob/master/django/db/models/sql/compiler.py#L412

In the jsonb `KeyTransform` code, we return a tuple https://github.com/django/django/blob/master/django/contrib/postgres/fields/jsonb.py#L115

Which makes `PostgresSimpleLookup.as_sql` fail: https://github.com/django/django/blob/master/django/contrib/postgres/lookups.py#L11 because `lhs_params` is a tuple and `rhs_params` is a list.

```
lhs_params ('d',)
rhs_params [<django.contrib.postgres.fields.jsonb.JsonAdapter object at 0x104e7f090>]
```

The fact that it's a tuple was introduced here: https://github.com/django/django/commit/6c3dfba89215fc56fc27ef61829a6fff88be4abb to fix a subquery bug.
